### PR TITLE
Refactor navigation by centralizing calls in router

### DIFF
--- a/src/game-detail/game-detail.html
+++ b/src/game-detail/game-detail.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="./plugin-list.css">
 
 <template>
-    <section class="partial" data-game-detail>
+    <section class="partial" data-partial data-game-detail>
         <header class="game-detail-header">
             <a class="game-detail-header-back" data-game-detail-header-back>&lt;</a>
             <h1 class="game-detail-title" data-game-detail-name></h1>

--- a/src/list-steamapps/list-steamapps.html
+++ b/src/list-steamapps/list-steamapps.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="./list-steamapps.css">
 
 <template>
-    <section class="partial is-shown" data-list-games>
+    <section class="partial is-shown" data-partial data-list-games>
         <ul class="list-steamapps"></ul>
     </section>
 </template>

--- a/src/list-steamapps/list-steamapps.js
+++ b/src/list-steamapps/list-steamapps.js
@@ -14,9 +14,6 @@ const slugify = require('github-slugid');
 const vdf = require('vdfjs');
 const winreg = require('winreg');
 
-const renderGameDetail = require('../game-detail/game-detail.js');
-const router = require('../router.js');
-
 const cachePath = envPaths('ayria-desktop', {suffix: ''}).cache;
 const steamappsCache = flatCache.load('steamapps', cachePath);
 
@@ -131,7 +128,6 @@ const renderSteamapp = function (appData) {
     const appSlug = slugify(String(appData.name));
 
     // Fill in DOM nodes with data
-    appLink.setAttribute('href', `./game-detail/game-detail.html#${appSlug}`);
     appName.textContent = appData.name;
     appBackground.src = appData.background;
     appBackground.alt = '';
@@ -139,8 +135,14 @@ const renderSteamapp = function (appData) {
     appLink.addEventListener('click', function (event) {
         event.preventDefault();
 
-        renderGameDetail(appSlug, appData);
-        router.onlyShowPartial('game-detail');
+        document.dispatchEvent(
+            new CustomEvent('navigate', {
+                detail: {
+                    state: Object.assign({}, appData, {appSlug}),
+                    viewName: 'game-detail',
+                }
+            })
+        );
     });
 
     // Construct and insert DOM structure
@@ -211,3 +213,7 @@ getSteamappsPaths()
     .then(steamapps => Promise.all(steamapps).then(() => {
         steamappsCache.save();
     }));
+
+module.exports = {
+    render: renderSteamapp,
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,21 +1,21 @@
 'use strict';
 
+const routes = require('./routes');
+
 const hideAllpartials = function () {
-    // refine this querySelectorAll
-    const partials = document.querySelectorAll('.is-shown');
-    Array.prototype.forEach.call(partials, function (partial) {
+    const partials = document.querySelectorAll('[data-partial]');
+
+    for (let partial of partials) {
         partial.classList.remove('is-shown');
-    });
+    };
 };
 
-const onlyShowPartial = function (name) {
-    hideAllpartials();
-
-    // Display the current partial
+const showPartial = function (name) {
     document.querySelector(`[data-${name}]`).classList.add('is-shown');
 };
 
-module.exports = {
-    hideAllpartials: hideAllpartials,
-    onlyShowPartial: onlyShowPartial
-};
+document.addEventListener('navigate', function (event) {
+  routes[event.detail.viewName].render(event.detail.state);
+  hideAllpartials();
+  showPartial(event.detail.viewName);
+});

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const gameDetail = require('./game-detail/game-detail');
+const listSteamapps = require('./list-steamapps/list-steamapps');
+
+module.exports = {
+    'game-detail': gameDetail,
+    'list-games': listSteamapps,
+};


### PR DESCRIPTION
Remove view specific code requiring the router and/or other views.
Instead emit navigation events handled by the router.